### PR TITLE
Add "Grid to Container Distance Adjustment" Feature to Line Chart, Heat Map, and Scatter

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+examples/*
+images_for_github/*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Embedding Interactive Charts Generated with ECharts Library into Shiny
         Applications
 Imports: shiny,jsonlite
-Version: 0.2.11
-Date: 2017-05-09
+Version: 0.2.12
+Date: 2017-08-19
 Authors@R: c(
     person("Xiaodong", "Deng", role = c("aut", "cre"), email = "xd_deng@hotmail.com"),
     person("Hao", "Zhu", role = "ctr", email = "haozhu233@gmail.com"),

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 --------------------
 Version 0.2.10
 --------------------
+- Add "grid to container distance adjustment" feature for Line Chart, Heat Map, and Scatter. In previous version, only Bar Chart supports this feature.
+
+--------------------
+Version 0.2.10
+--------------------
 - Upgrade ECharts Javascript file. This also helped fix the bug of word cloud raised in GitHub issue #46
 - Added the themes contributed by Janet Wagner
 - Removed some unnecessary tedious codes

--- a/R/bar_chart.R
+++ b/R/bar_chart.R
@@ -45,15 +45,15 @@ renderBarChart <- function(div_id,
     stop("The length of 'hyperlinks' should be the same as the number of observations (the number of rows of the data).")
   }
 
-  xaxis_name <- paste(sapply(row.names(data), function(x){paste("'", x, "'", sep="")}), collapse=", ")
-  xaxis_name <- paste("[", xaxis_name, "]", sep="")
-  legend_name <- paste(sapply(names(data), function(x){paste("'", x, "'", sep="")}), collapse=", ")
-  legend_name <- paste("[", legend_name, "]", sep="")
+  xaxis_name <- paste(sapply(row.names(data), function(x){paste0("'", x, "'")}), collapse=", ")
+  xaxis_name <- paste0("[", xaxis_name, "]")
+  legend_name <- paste(sapply(names(data), function(x){paste0("'", x, "'")}), collapse=", ")
+  legend_name <- paste0("[", legend_name, "]")
 
   # Convert raw data into JSON format (Prepare the data in "series" part)
   series_data <- rep("", dim(data)[2])
   for(i in 1:length(series_data)){
-    temp <- paste("{name:'", names(data)[i], "', type:'bar', ",
+    temp <- paste0("{name:'", names(data)[i], "', type:'bar', ",
 
                   ifelse(stack_plot,
                          " stack:' ', ",
@@ -61,19 +61,18 @@ renderBarChart <- function(div_id,
 
                   ifelse(is.null(bar.max.width),
                          "barMaxWidth: null,",
-                         paste("barMaxWidth:'", bar.max.width, "',", sep="")),
+                         paste0("barMaxWidth:'", bar.max.width, "',")),
 
                   "data:[",
                   paste(data[, i], collapse = ", "),
-                  "]}",
-                  sep=""
+                  "]}"
     )
     series_data[i] <- temp
   }
   series_data <- paste(series_data, collapse = ", ")
-  series_data <- paste("[", series_data, "]", sep="")
+  series_data <- paste0("[", series_data, "]")
 
-  js_statement <- paste("var " ,
+  js_statement <- paste0("var " ,
                         div_id,
                         " = echarts.init(document.getElementById('",
                         div_id,
@@ -97,17 +96,16 @@ renderBarChart <- function(div_id,
                                "animation:false,"),
 
                         ifelse(show.legend,
-                               paste("legend:{data:",
+                               paste0("legend:{data:",
                                      legend_name,
                                      ", textStyle:{fontSize:", font.size.legend, "}",
-                                     "},",
-                                     sep=""),
+                                     "},"),
                                ""),
                         "grid: {left:'", grid_left, "', right:'", grid_right, "', top:'", grid_top, "', bottom:'", grid_bottom, "', containLabel: true},",
                         direction_vector[1],
-                        ":[{type:'value', name:", ifelse(is.null(axis.y.name), 'null', paste("'", axis.y.name, "'", sep="")), ", axisLabel:{rotate:", rotate.axis.y, ",textStyle:{fontSize:", font.size.axis.y, "}}}], ",
+                        ":[{type:'value', name:", ifelse(is.null(axis.y.name), 'null', paste0("'", axis.y.name, "'")), ", axisLabel:{rotate:", rotate.axis.y, ",textStyle:{fontSize:", font.size.axis.y, "}}}], ",
                         direction_vector[2],
-                        ":[{type:'category', name:", ifelse(is.null(axis.x.name), 'null', paste("'", axis.x.name, "'", sep="")), ", axisTick:{show:false}, axisLabel:{rotate:", rotate.axis.x, ",textStyle:{fontSize:", font.size.axis.x, "}}, data:",
+                        ":[{type:'category', name:", ifelse(is.null(axis.x.name), 'null', paste0("'", axis.x.name, "'")), ", axisTick:{show:false}, axisLabel:{rotate:", rotate.axis.x, ",textStyle:{fontSize:", font.size.axis.x, "}}, data:",
                         xaxis_name,
                         "}],series :",
                         series_data,
@@ -124,29 +122,24 @@ renderBarChart <- function(div_id,
 
                         ifelse(is.null(hyperlinks),
                                "",
-                               paste(div_id,
+                               paste0(div_id,
                                     ".on('click', function (param){
                                     var name=param.name;",
 
                                      paste(sapply(1:length(hyperlinks),
                                                   function(i){
-                                                    paste("if(name=='", row.names(data)[i], "'){",
-                                                          "window.location.href='", hyperlinks[i], "';}",
-                                                          sep="")
+                                                    paste0("if(name=='", row.names(data)[i], "'){",
+                                                          "window.location.href='", hyperlinks[i], "';}")
                                                   }),
                                            collapse = ""),
 
                                 "});",
-                                div_id, ".on('click');",
-                                sep="")
-                               ),
+                                div_id, ".on('click');")
+                               ))
 
-                        sep="")
-
-  to_eval <- paste("output$", div_id ," <- renderUI({tags$script(\"",
+  to_eval <- paste0("output$", div_id ," <- renderUI({tags$script(\"",
                    js_statement,
-                   "\")})",
-                   sep="")
+                   "\")})")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval), envir = parent.frame())

--- a/R/deliverChart.R
+++ b/R/deliverChart.R
@@ -1,10 +1,9 @@
 deliverChart <- function(div_id,
                         running_in_shiny = TRUE){
-  
-  to_eval <- paste("uiOutput(\"",
+
+  to_eval <- paste0("uiOutput(\"",
                    div_id,
-                   "\")",
-                   sep="")
+                   "\")")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval)

--- a/R/heat_map.R
+++ b/R/heat_map.R
@@ -5,6 +5,7 @@
 renderHeatMap <- function(div_id, data,
                           theme = "default",
                           show.tools = TRUE,
+                          grid_left = "3%", grid_right = "4%", grid_top = "16%", grid_bottom = "3%",
                           running_in_shiny = TRUE){
 
   data <- isolate(data)
@@ -45,6 +46,8 @@ renderHeatMap <- function(div_id, data,
                         ifelse(show.tools,
                                "toolbox: {feature: {saveAsImage: {}}},",
                                ""),
+
+                        "grid: {left:'", grid_left, "', right:'", grid_right, "', top:'", grid_top, "', bottom:'", grid_bottom, "', containLabel: true},",
 
                         "xAxis: {type: 'category',data: [",
                         ifelse(is.null(row_names),

--- a/R/heat_map.R
+++ b/R/heat_map.R
@@ -25,7 +25,7 @@ renderHeatMap <- function(div_id, data,
   .check_logical(c('show.tools','running_in_shiny'))
 
   # Convert raw data into JSON format
-  series_data <- paste("[{type: 'heatmap',data:", .prepare_data_for_heatmap(processed_data), ",itemStyle: {emphasis: {shadowBlur: 10,shadowColor: 'rgba(0, 0, 0, 0.5)'}}}]", sep="")
+  series_data <- paste0("[{type: 'heatmap',data:", .prepare_data_for_heatmap(processed_data), ",itemStyle: {emphasis: {shadowBlur: 10,shadowColor: 'rgba(0, 0, 0, 0.5)'}}}]")
 
   # prepare axis labels
 
@@ -33,7 +33,7 @@ renderHeatMap <- function(div_id, data,
   col_names <- colnames(data)
 
 
-  js_statement <- paste("var ",
+  js_statement <- paste0("var ",
                         div_id,
                         " = echarts.init(document.getElementById('",
                         div_id,
@@ -54,7 +54,7 @@ renderHeatMap <- function(div_id, data,
                                "' '",
                                paste(sapply(row_names,
                                             function(x){
-                                              paste("'", x, "'", sep="")
+                                              paste0("'", x, "'")
                                             }), collapse = ",")),
                         "],splitArea: {show: true}},",
 
@@ -64,7 +64,7 @@ renderHeatMap <- function(div_id, data,
                                "' '",
                                paste(sapply(col_names,
                                             function(x){
-                                              paste("'", x, "'", sep="")
+                                              paste0("'", x, "'")
                                             }), collapse = ",")),
                         "],splitArea: {show: true}},",
 
@@ -81,14 +81,11 @@ renderHeatMap <- function(div_id, data,
 
                         "window.addEventListener('resize', function(){",
                         div_id, ".resize()",
-                        "});",
+                        "});")
 
-                        sep="")
-
-  to_eval <- paste("output$", div_id ," <- renderUI({tags$script(\"",
+  to_eval <- paste0("output$", div_id ," <- renderUI({tags$script(\"",
                    js_statement,
-                   "\")})",
-                   sep="")
+                   "\")})")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval), envir = parent.frame())

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -16,7 +16,7 @@
 
   return(ifelse(theme == "default",
                 "",
-                paste(", '",theme,  "'", sep=""))
+                paste0(", '",theme,  "'"))
   )
 
 }
@@ -38,7 +38,7 @@
   temp <- c()
   for(i in 1:n_row){
     for(j in 1:n_col){
-      temp <- c(temp, paste("[", i, ",", j, ",", dat[i,j], "]", sep=""))
+      temp <- c(temp, paste0("[", i, ",", j, ",", dat[i,j], "]"))
     }
   }
   temp <- paste(temp, collapse = ", ")

--- a/R/line_chart.R
+++ b/R/line_chart.R
@@ -14,6 +14,7 @@ renderLineChart <- function(div_id,
                             rotate.axis.x = 0, rotate.axis.y = 0,
                             show.slider.axis.x = FALSE, show.slider.axis.y = FALSE,
                             animation = TRUE,
+                            grid_left = "3%", grid_right = "4%", grid_top = "16%", grid_bottom = "3%",
                             running_in_shiny = TRUE){
 
   data <- isolate(data)
@@ -92,10 +93,10 @@ renderLineChart <- function(div_id,
   # Check the value for theme
   theme_placeholder <- .theme_placeholder(theme)
 
-  xaxis_name <- paste(sapply(row.names(data), function(x){paste("'", x, "'", sep="")}), collapse=", ")
-  xaxis_name <- paste("[", xaxis_name, "]", sep="")
-  legend_name <- paste(sapply(names(data), function(x){paste("'", x, "'", sep="")}), collapse=", ")
-  legend_name <- paste("[", legend_name, "]", sep="")
+  xaxis_name <- paste(sapply(row.names(data), function(x){paste0("'", x, "'")}), collapse=", ")
+  xaxis_name <- paste0("[", xaxis_name, "]")
+  legend_name <- paste(sapply(names(data), function(x){paste0("'", x, "'")}), collapse=", ")
+  legend_name <- paste0("[", legend_name, "]")
 
   step_statement <- ifelse(step == 'null',
                            "step:false,",
@@ -104,12 +105,12 @@ renderLineChart <- function(div_id,
   # Convert raw data into JSON format
   series_data <- rep("", dim(data)[2])
   for(i in 1:length(series_data)){
-    temp <- paste("{name:'", names(data)[i], "', type:'line', ",
+    temp <- paste0("{name:'", names(data)[i], "', type:'line', ",
 
                   step_statement,
 
-                  paste("symbolSize:", point.size[i], ",", sep=""),
-                  paste("symbol:'", point.type[i], "',", sep=""),
+                  paste0("symbolSize:", point.size[i], ","),
+                  paste0("symbol:'", point.type[i], "',"),
 
                   "itemStyle:{normal:{lineStyle: {width:", line.width[i],", type:'", line.type[i], "'}}},",
 
@@ -118,15 +119,14 @@ renderLineChart <- function(div_id,
                          " "),
                   "data:[",
                   paste(data[, i], collapse = ", "),
-                  "]}",
-                  sep=""
-    )
+                  "]}")
+
     series_data[i] <- temp
   }
   series_data <- paste(series_data, collapse = ", ")
 
 
-  js_statement <- paste("var " ,
+  js_statement <- paste0("var " ,
                         div_id,
                         " = echarts.init(document.getElementById('",
                         div_id,
@@ -139,6 +139,8 @@ renderLineChart <- function(div_id,
                                "toolbox:{feature:{saveAsImage:{}}}, ",
                                ""),
 
+                        "grid: {left:'", grid_left, "', right:'", grid_right, "', top:'", grid_top, "', bottom:'", grid_bottom, "', containLabel: true},",
+
                         ifelse(show.slider.axis.x == TRUE & show.slider.axis.y == FALSE,
                                "dataZoom: [{type:'slider', xAxisIndex : 0}],",
                                ifelse(show.slider.axis.x == FALSE & show.slider.axis.y == TRUE,
@@ -149,19 +151,18 @@ renderLineChart <- function(div_id,
                                )),
 
                         ifelse(show.legend,
-                               paste("legend:{data:",
+                               paste0("legend:{data:",
                                      legend_name,
                                      ", textStyle:{fontSize:", font.size.legend, "}",
-                                     "},",
-                                     sep=""),
+                                     "},"),
                                ""),
 
                         ifelse(animation,
                                "animation:true,",
                                "animation:false,"),
 
-                        "yAxis:{type: 'value', name:", ifelse(is.null(axis.y.name), 'null', paste("'", axis.y.name, "'", sep="")), ", axisLabel:{rotate:",rotate.axis.y,",textStyle:{fontSize:", font.size.axis.y, "}}}, ",
-                        "xAxis:{type:'category', name:", ifelse(is.null(axis.x.name), 'null', paste("'", axis.x.name, "'", sep="")), ", boundaryGap: false, axisLabel:{rotate:", rotate.axis.x, ",textStyle:{fontSize:", font.size.axis.x, "}}, data:",
+                        "yAxis:{type: 'value', name:", ifelse(is.null(axis.y.name), 'null', paste0("'", axis.y.name, "'")), ", axisLabel:{rotate:",rotate.axis.y,",textStyle:{fontSize:", font.size.axis.y, "}}}, ",
+                        "xAxis:{type:'category', name:", ifelse(is.null(axis.x.name), 'null', paste0("'", axis.x.name, "'")), ", boundaryGap: false, axisLabel:{rotate:", rotate.axis.x, ",textStyle:{fontSize:", font.size.axis.x, "}}, data:",
                         xaxis_name,
                         "}, series:[",
                         series_data,
@@ -174,14 +175,11 @@ renderLineChart <- function(div_id,
 
                         "window.addEventListener('resize', function(){",
                         div_id, ".resize()",
-                        "});",
+                        "});")
 
-                        sep="")
-
-  to_eval <- paste("output$", div_id ," <- renderUI({tags$script(\"",
+  to_eval <- paste0("output$", div_id ," <- renderUI({tags$script(\"",
                    js_statement,
-                   "\")})",
-                   sep="")
+                   "\")})")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval), envir = parent.frame())

--- a/R/loadEChartsTheme.R
+++ b/R/loadEChartsTheme.R
@@ -7,10 +7,9 @@ loadEChartsTheme <- function(theme){
     stop("The ECharts theme you specified is invalid. Please check. Valid values include: 'default', 'roma', 'infographic', 'macarons', 'vintage', 'shine', 'caravan', 'dark-digerati', 'jazz', and 'london'.")
   }
 
-  to_eval=paste('includeScript(system.file("',
+  to_eval=paste0('includeScript(system.file("',
                 theme,
-                '.js", package = "ECharts2Shiny"))',
-                sep="")
+                '.js", package = "ECharts2Shiny"))')
   eval(parse(text = to_eval), envir = parent.frame())
 }
 

--- a/R/pie_chart.R
+++ b/R/pie_chart.R
@@ -62,14 +62,14 @@ renderPieChart <- function(div_id,
 
 
   # Generate legend
-  legend_data <- paste(sapply(sort(unique(data$name)), function(x){paste("'", x, "'", sep="")}), collapse=", ")
-  legend_data <- paste("[", legend_data, "]", sep="")
+  legend_data <- paste(sapply(sort(unique(data$name)), function(x){paste0("'", x, "'")}), collapse=", ")
+  legend_data <- paste0("[", legend_data, "]")
 
   # Convert raw data into JSON format
   data <- as.character(jsonlite::toJSON(data))
   data <- gsub("\"", "\'", data)
 
-  js_statement <- paste("var " ,
+  js_statement <- paste0("var " ,
                         div_id,
                         " = echarts.init(document.getElementById('",
                         div_id,
@@ -88,11 +88,10 @@ renderPieChart <- function(div_id,
                                "tooltip : {textStyle: {fontStyle:'italic', color:'skyblue'}},"),
 
                         ifelse(show.legend,
-                               paste("legend:{orient: 'vertical', left: 'left', data:",
+                               paste0("legend:{orient: 'vertical', left: 'left', data:",
                                      legend_data,
                                      ", textStyle:{fontSize:", font.size.legend, "}",
-                                     "},",
-                                     sep=""),
+                                     "},"),
                                ""),
                         "series : [{type: 'pie', radius:'", radius, "', center :['", center_x, "','", center_y, "'],",
 
@@ -119,29 +118,24 @@ renderPieChart <- function(div_id,
 
                         ifelse(is.null(hyperlinks),
                                "",
-                               paste(div_id,
+                               paste0(div_id,
                                      ".on('click', function (param){
                                      var name=param.name;",
 
                                      paste(sapply(1:length(hyperlinks),
                                                   function(i){
-                                                    paste("if(name=='", item_names[i], "'){",
-                                                          "window.location.href='", hyperlinks[i], "';}",
-                                                          sep="")
+                                                    paste0("if(name=='", item_names[i], "'){",
+                                                          "window.location.href='", hyperlinks[i], "';}")
                                                   }),
                                            collapse = ""),
 
                                      "});",
-                                     div_id, ".on('click');",
-                                     sep="")
-                        ),
+                                     div_id, ".on('click');")
+                        ))
 
-                        sep="")
-
-  to_eval <- paste("output$", div_id ," <- renderUI({tags$script(\"",
+  to_eval <- paste0("output$", div_id ," <- renderUI({tags$script(\"",
                    js_statement,
-                   "\")})",
-                   sep="")
+                   "\")})")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval), envir = parent.frame())

--- a/R/scatter.R
+++ b/R/scatter.R
@@ -13,6 +13,7 @@ renderScatter <- function(div_id, data,
                           rotate.axis.x = 0, rotate.axis.y = 0,
                           show.slider.axis.x = FALSE, show.slider.axis.y = FALSE,
                           animation = TRUE,
+                          grid_left = "3%", grid_right = "4%", grid_top = "16%", grid_bottom = "3%",
                           running_in_shiny = TRUE){
 
   data <- isolate(data)
@@ -110,6 +111,8 @@ renderScatter <- function(div_id, data,
                         ifelse(show.tools,
                                "toolbox:{feature:{dataZoom:{show: true},restore:{show: true},saveAsImage:{show: true}}}, ",
                                ""),
+
+                        "grid: {left:'", grid_left, "', right:'", grid_right, "', top:'", grid_top, "', bottom:'", grid_bottom, "', containLabel: true},",
 
                         ifelse(show.legend,
                                paste("legend:{data:",

--- a/R/scatter.R
+++ b/R/scatter.R
@@ -66,8 +66,8 @@ renderScatter <- function(div_id, data,
   # get the unique values of "group" column
   group_names <- sort(unique(data$group))
 
-  legend_name <- paste(sapply(group_names, function(x){paste("'", x, "'", sep="")}), collapse=", ")
-  legend_name <- paste("[", legend_name, "]", sep="")
+  legend_name <- paste(sapply(group_names, function(x){paste0("'", x, "'")}), collapse=", ")
+  legend_name <- paste0("[", legend_name, "]")
 
 
   # Convert raw data into JSON format (Prepare the data in "series" part)
@@ -76,29 +76,27 @@ renderScatter <- function(div_id, data,
 
     temp_data <- data[data$group == group_names[i],]
 
-    temp <- paste("{name:'", group_names[i], "', type:'scatter', ",
+    temp <- paste0("{name:'", group_names[i], "', type:'scatter', ",
 
-                  paste("symbolSize:", point.size, ",", sep=""),
-                  paste("symbol:'", point.type[i], "',", sep=""),
+                  paste0("symbolSize:", point.size, ","),
+                  paste0("symbol:'", point.type[i], "',"),
 
                   "data:[",
                   paste(sapply(1:dim(temp_data)[1],
                                function(j){
-                                 paste("[", temp_data[j, "x"],
+                                 paste0("[", temp_data[j, "x"],
                                        ",",
-                                       temp_data[j, "y"],"]",
-                                       sep="")
+                                       temp_data[j, "y"],"]")
                                }),
                         collapse = ","),
-                  "]}",
-                  sep="")
+                  "]}")
     series_data[i] <- temp
   }
   series_data <- paste(series_data, collapse = ", ")
-  series_data <- paste("[", series_data, "]", sep="")
+  series_data <- paste0("[", series_data, "]")
 
 
-  js_statement <- paste("var " ,
+  js_statement <- paste0("var " ,
                         div_id,
                         " = echarts.init(document.getElementById('",
                         div_id,
@@ -115,11 +113,10 @@ renderScatter <- function(div_id, data,
                         "grid: {left:'", grid_left, "', right:'", grid_right, "', top:'", grid_top, "', bottom:'", grid_bottom, "', containLabel: true},",
 
                         ifelse(show.legend,
-                               paste("legend:{data:",
+                               paste0("legend:{data:",
                                      legend_name,
                                      ", textStyle:{fontSize:", font.size.legend, "}",
-                                     "},",
-                                     sep=""),
+                                     "},"),
                                ""),
 
                         ifelse(animation,
@@ -137,18 +134,18 @@ renderScatter <- function(div_id, data,
 
                         ifelse(auto.scale,
 
-                               paste("xAxis:[{type : 'value', name:", ifelse(is.null(axis.x.name), 'null', paste("'", axis.x.name, "'", sep="")), ", scale:true, axisLabel:{rotate:",
+                               paste0("xAxis:[{type : 'value', name:", ifelse(is.null(axis.x.name), 'null', paste0("'", axis.x.name, "'")), ", scale:true, axisLabel:{rotate:",
                                      rotate.axis.x,
                                      ",textStyle:{fontSize:",
                                      font.size.axis.x,
                                      "}}}],",
-                                     "yAxis:[{type:'value', name:", ifelse(is.null(axis.y.name), 'null', paste("'", axis.y.name, "'", sep="")), ", scale:true,axisLabel:{rotate:",
+                                     "yAxis:[{type:'value', name:", ifelse(is.null(axis.y.name), 'null', paste0("'", axis.y.name, "'")), ", scale:true,axisLabel:{rotate:",
                                      rotate.axis.y,
                                      ",textStyle:{fontSize:",
                                      font.size.axis.y,
-                                     "}}}],", sep=""),
+                                     "}}}],"),
 
-                               paste("xAxis:[{gridIndex: 0, axisLabel:{rotate:", rotate.axis.x, ",textStyle:{fontSize:", font.size.axis.x, "}}, min: ",
+                               paste0("xAxis:[{gridIndex: 0, axisLabel:{rotate:", rotate.axis.x, ",textStyle:{fontSize:", font.size.axis.x, "}}, min: ",
                                      round(min(data$x) - 0.03 * diff(range(data$x)), 1) - 0.1,
                                      ", max: ",
                                      round(max(data$x) + 0.03 * diff(range(data$x)), 1) + 0.1,
@@ -156,8 +153,7 @@ renderScatter <- function(div_id, data,
                                      round(min(data$y) - 0.03 * diff(range(data$y)), 1) - 0.1,
                                      ", max: ",
                                      round(max(data$y) + 0.03 * diff(range(data$y)), 1) + 0.1,
-                                     "}],",
-                                     sep="")
+                                     "}],")
                         ),
 
                         "series :",
@@ -171,14 +167,11 @@ renderScatter <- function(div_id, data,
 
                         "window.addEventListener('resize', function(){",
                         div_id, ".resize()",
-                        "});",
+                        "});")
 
-                        sep="")
-
-  to_eval <- paste("output$", div_id ," <- renderUI({tags$script(\"",
+  to_eval <- paste0("output$", div_id ," <- renderUI({tags$script(\"",
                    js_statement,
-                   "\")})",
-                   sep="")
+                   "\")})")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval), envir = parent.frame())

--- a/R/tree_map.R
+++ b/R/tree_map.R
@@ -28,7 +28,7 @@ renderTreeMap <- function(div_id,
     stop("Argument 'leafDepth' must be bigger than 0.")
   }
 
-  js_statement <- paste("var " ,
+  js_statement <- paste0("var " ,
                         div_id,
                         " = echarts.init(document.getElementById('",
                         div_id,
@@ -66,14 +66,11 @@ renderTreeMap <- function(div_id,
 
                         "window.addEventListener('resize', function(){",
                         div_id, ".resize()",
-                        "});",
+                        "});")
 
-                        sep="")
-
-  to_eval <- paste("output$", div_id ," <- renderUI({tags$script(\"",
+  to_eval <- paste0("output$", div_id ," <- renderUI({tags$script(\"",
                    js_statement,
-                   "\")})",
-                   sep="")
+                   "\")})")
 
   if(running_in_shiny == TRUE){
     eval(parse(text = to_eval), envir = parent.frame())

--- a/man/renderBarChart.Rd
+++ b/man/renderBarChart.Rd
@@ -39,16 +39,16 @@ Whether do stack bar chart. The default value is FALSE.
   The direction of the bar chart. Valid values include "vertical" and "horizontal". Default value is "horizontal".
 }
   \item{grid_left}{
-  The grid left for the left side. Default value is "3\%".
+  Distance between grid component and the left side of the container. Default value is "3\%".
 }
   \item{grid_right}{
-  The grid left for the right side. Default value is "4\%".
+  Distance between grid component and the right side of the container. Default value is "4\%".
 }
   \item{grid_top}{
-  The grid left for the top side. Default value is "16\%".
+  Distance between grid component and the top side of the container. Default value is "16\%".
 }
   \item{grid_bottom}{
-  The grid left for the bottom side. Default value is "3\%".
+  Distance between grid component and the bottom side of the container. Default value is "3\%".
 }
   \item{show.legend}{
 If display the legends. The default value is TRUE.

--- a/man/renderHeatMap.Rd
+++ b/man/renderHeatMap.Rd
@@ -10,6 +10,7 @@ renderHeatMap() function helps render heat map charts into Shiny applications.
 renderHeatMap(div_id, data,
               theme = "default",
               show.tools = TRUE,
+              grid_left = "3\%", grid_right = "4\%", grid_top = "16\%", grid_bottom = "3\%",
               running_in_shiny = TRUE)
 }
 %- maybe also 'usage' for other objects documented here.
@@ -27,6 +28,18 @@ Which ECharts theme to use. Valid values include "default", "roma", "infographic
 }
   \item{show.tools}{
 If display the tool bar. The default value is TRUE.
+}
+  \item{grid_left}{
+  Distance between grid component and the left side of the container. Default value is "3\%".
+}
+  \item{grid_right}{
+  Distance between grid component and the right side of the container. Default value is "4\%".
+}
+  \item{grid_top}{
+  Distance between grid component and the top side of the container. Default value is "16\%".
+}
+  \item{grid_bottom}{
+  Distance between grid component and the bottom side of the container. Default value is "3\%".
 }
   \item{running_in_shiny}{
       If we're actually running this in a Shiny library, or we're simply doing testing. Default valus is "TRUE". If "FALSE", the function will print what it's supposed to evaluate.

--- a/man/renderLineChart.Rd
+++ b/man/renderLineChart.Rd
@@ -19,6 +19,7 @@ renderLineChart(div_id, data, theme = "default",
                 rotate.axis.x = 0, rotate.axis.y = 0,
                 show.slider.axis.x = FALSE, show.slider.axis.y = FALSE,
                 animation = TRUE,
+                grid_left = "3\%", grid_right = "4\%", grid_top = "16\%", grid_bottom = "3\%",
                 running_in_shiny = TRUE)
 }
 %- maybe also 'usage' for other objects documented here.
@@ -103,6 +104,18 @@ Whether display slider on Y axis. The default value is FALSE.
 }
   \item{animation}{
 Whether display the chart with animation. The default value is TRUE.
+}
+  \item{grid_left}{
+  Distance between grid component and the left side of the container. Default value is "3\%".
+}
+  \item{grid_right}{
+  Distance between grid component and the right side of the container. Default value is "4\%".
+}
+  \item{grid_top}{
+  Distance between grid component and the top side of the container. Default value is "16\%".
+}
+  \item{grid_bottom}{
+  Distance between grid component and the bottom side of the container. Default value is "3\%".
 }
   \item{running_in_shiny}{
       If we're actually running this in a Shiny library, or we're simply doing testing. Default valus is "TRUE". If "FALSE", the function will print what it's supposed to evaluate.

--- a/man/renderScatter.Rd
+++ b/man/renderScatter.Rd
@@ -17,6 +17,7 @@ renderScatter(div_id, data,
               rotate.axis.x = 0, rotate.axis.y = 0,
               show.slider.axis.x = FALSE, show.slider.axis.y = FALSE,
               animation = TRUE,
+              grid_left = "3\%", grid_right = "4\%", grid_top = "16\%", grid_bottom = "3\%",
               running_in_shiny = TRUE)
 }
 \arguments{
@@ -77,6 +78,18 @@ Whether display slider on Y axis. The default value is FALSE.
 }
   \item{animation}{
 Whether display the chart with animation. The default value is TRUE.
+}
+  \item{grid_left}{
+  Distance between grid component and the left side of the container. Default value is "3\%".
+}
+  \item{grid_right}{
+  Distance between grid component and the right side of the container. Default value is "4\%".
+}
+  \item{grid_top}{
+  Distance between grid component and the top side of the container. Default value is "16\%".
+}
+  \item{grid_bottom}{
+  Distance between grid component and the bottom side of the container. Default value is "3\%".
 }
   \item{running_in_shiny}{
       If we're actually running this in a Shiny library, or we're simply doing testing. Default valus is "TRUE". If "FALSE", the function will print what it's supposed to evaluate.


### PR DESCRIPTION
This feature was only available for Bar Chart.

The codes are also cleaned a bit, mainly change `paste(..., sep="")` into `paste0(...)`.